### PR TITLE
Load .env file and improve error handling for station list

### DIFF
--- a/radiko_recorder/__init__.py
+++ b/radiko_recorder/__init__.py
@@ -123,8 +123,11 @@ def main(argv=None):
     args = parser.parse_args(argv)
     
     if args.station_list:
-        # 放送局リストを表示
-        _show_station_list(args.area_id)
+        try:
+            # 放送局リストを表示
+            _show_station_list(args.area_id)
+        except ValueError as e:
+            print(e)
         return
     
     # 必須引数のチェック

--- a/radiko_recorder/config.py
+++ b/radiko_recorder/config.py
@@ -2,7 +2,8 @@ import os
 
 from dotenv import load_dotenv
 
-# 環境変数へ反映
-load_dotenv()
+# 現在のスクリプトのディレクトリから.envをロード
+dotenv_path = os.path.join(os.path.dirname(__file__), '.env')
+load_dotenv(dotenv_path)
 
-RADIKO_AREA_ID = os.getenv('RADIKO_AREA_ID')
+RADIKO_AREA_ID = os.getenv('RADIKO_AREA_ID', 'JP13')  # デフォルト値として東京エリア（JP13）を指定

--- a/test.ipynb
+++ b/test.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -45,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
Load the .env file from the current script directory and set a default value for RADIKO_AREA_ID. Add error handling to display the station list, ensuring that any ValueError is caught and printed.